### PR TITLE
Add WireGuard and SRTP descriptions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,73 @@
+## SRTP
+
+XXX: https://tools.ietf.org/html/rfc3711
+XXX: https://tools.ietf.org/html/rfc5763
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## Signal
+
+XXX
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## ZRTP
+
+XXX: http://zfoneproject.com/faq.html#keycontinuity
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## SS-TLS
+
+XXX: https://www.esat.kuleuven.be/cosic/publications/article-2806.pdf
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## NTor
+
+XXX
+
+XXX: https://gitweb.torproject.org/torspec.git/tree/proposals/216-ntor-handshake.txt
+XXX: http://www.cypherpunks.ca/~iang/pubs/torsec.pdf
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## TAP
+
+XXX: https://svn.torproject.org/svn/projects/design-paper/tor-design.pdf
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## OTR
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## WireGuard
+
+XXX: https://www.wireguard.com/papers/wireguard.pdf
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## NoiseSocket
+
+XXX: http://noiseprotocol.org/specs/noisesocket.html
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,3 @@
-## SRTP
-
-XXX: https://tools.ietf.org/html/rfc3711
-XXX: https://tools.ietf.org/html/rfc5763
-
-### Protocol descriptions
-### Protocol features
-### Protocol dependencies
-
 ## Signal
 
 XXX
@@ -15,13 +6,6 @@ XXX
 ### Protocol features
 ### Protocol dependencies
 
-## ZRTP
-
-XXX: http://zfoneproject.com/faq.html#keycontinuity
-
-### Protocol descriptions
-### Protocol features
-### Protocol dependencies
 
 ## SS-TLS
 
@@ -32,8 +16,6 @@ XXX: https://www.esat.kuleuven.be/cosic/publications/article-2806.pdf
 ### Protocol dependencies
 
 ## NTor
-
-XXX
 
 XXX: https://gitweb.torproject.org/torspec.git/tree/proposals/216-ntor-handshake.txt
 XXX: http://www.cypherpunks.ca/~iang/pubs/torsec.pdf
@@ -50,20 +32,6 @@ XXX: https://svn.torproject.org/svn/projects/design-paper/tor-design.pdf
 ### Protocol features
 ### Protocol dependencies
 
-## OTR
-
-### Protocol descriptions
-### Protocol features
-### Protocol dependencies
-
-## WireGuard
-
-XXX: https://www.wireguard.com/papers/wireguard.pdf
-
-### Protocol descriptions
-### Protocol features
-### Protocol dependencies
-
 ## NoiseSocket
 
 XXX: http://noiseprotocol.org/specs/noisesocket.html
@@ -71,3 +39,30 @@ XXX: http://noiseprotocol.org/specs/noisesocket.html
 ### Protocol descriptions
 ### Protocol features
 ### Protocol dependencies
+
+## OTR
+
+XXX
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+
+## ZRTP
+
+XXX: http://zfoneproject.com/faq.html#keycontinuity
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+
+## SRTP
+
+XXX: https://tools.ietf.org/html/rfc3711
+XXX: https://tools.ietf.org/html/rfc5763
+
+### Protocol descriptions
+### Protocol features
+### Protocol dependencies
+

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,6 @@ XXX
 ### Protocol features
 ### Protocol dependencies
 
-
 ## SS-TLS
 
 XXX: https://www.esat.kuleuven.be/cosic/publications/article-2806.pdf
@@ -48,7 +47,6 @@ XXX
 ### Protocol features
 ### Protocol dependencies
 
-
 ## ZRTP
 
 XXX: http://zfoneproject.com/faq.html#keycontinuity
@@ -57,12 +55,4 @@ XXX: http://zfoneproject.com/faq.html#keycontinuity
 ### Protocol features
 ### Protocol dependencies
 
-## SRTP
-
-XXX: https://tools.ietf.org/html/rfc3711
-XXX: https://tools.ietf.org/html/rfc5763
-
-### Protocol descriptions
-### Protocol features
-### Protocol dependencies
 

--- a/draft-pauly-taps-transport-security.md
+++ b/draft-pauly-taps-transport-security.md
@@ -442,50 +442,6 @@ ESP packets are sent directly over IP, except when a NAT is present, in which ca
 
 - Since ESP is below transport protocols, it does not have any dependencies on the transports themselves, other than on UDP or TCP for NAT traversal.
 
-## SRTP
-
-XXX: https://tools.ietf.org/html/rfc3711
-XXX: https://tools.ietf.org/html/rfc5763
-
-## ZRTP
-
-XXX: http://zfoneproject.com/faq.html#keycontinuity
-
-## SS-TLS
-
-XXX: https://www.esat.kuleuven.be/cosic/publications/article-2806.pdf
-
-## WireGuard
-
-XXX: https://www.wireguard.com/papers/wireguard.pdf
-
-## NoiseSocket
-
-XXX: http://noiseprotocol.org/specs/noisesocket.html
-
-## CurveCP
-
-XXX
-
-## OTR
-
-XXX
-
-## Signal
-
-XXX
-
-## NTor
-
-XXX
-
-XXX: https://gitweb.torproject.org/torspec.git/tree/proposals/216-ntor-handshake.txt
-XXX: http://www.cypherpunks.ca/~iang/pubs/torsec.pdf
-
-## TAP
-
-XXX: https://svn.torproject.org/svn/projects/design-paper/tor-design.pdf
-
 # Common Transport Security Features
 
 There exists a common set of features shared across the transport protocols surveyed in this document.

--- a/draft-pauly-taps-transport-security.md
+++ b/draft-pauly-taps-transport-security.md
@@ -441,7 +441,42 @@ ESP packets are sent directly over IP, except when a NAT is present, in which ca
 
 ## SRTP
 
+XXX: https://tools.ietf.org/html/rfc3711
+XXX: https://tools.ietf.org/html/rfc5763
+
+### Protocol descriptions
+
 XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+## ZRTP
+
+XXX: http://zfoneproject.com/faq.html#keycontinuity
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+## SS-TLS
+
+XXX
+
+https://www.esat.kuleuven.be/cosic/publications/article-2806.pdf
 
 ### Protocol descriptions
 
@@ -456,6 +491,86 @@ XXX
 XXX
 
 ## WireGuard
+
+XXX
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+## NoiseSocket
+
+XXX
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+## CurveCP
+
+XXX
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+## OTR
+
+XXX
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+## Signal
+
+XXX
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+## NTor
 
 XXX
 
@@ -567,7 +682,7 @@ over a transport to establish trust and negotiate keys.
 Protocols: All (TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2)
 
 - Identity Validation  
-During a handshake, the security protocol will conduct identity validation of the peer. 
+During a handshake, the security protocol will conduct identity validation of the peer.
 This can call into the application to offload validation.  
 Protocols: All (TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2)
 

--- a/draft-pauly-taps-transport-security.md
+++ b/draft-pauly-taps-transport-security.md
@@ -173,7 +173,7 @@ for the server. It is assumed that the client must always store some state infor
 - Transparent data segmentation.
 
 <!-- caw: possibles to add -->
-- identity hiding
+<!-- - identity hiding -->
 
 ### Protocol Dependencies
 
@@ -447,97 +447,23 @@ ESP packets are sent directly over IP, except when a NAT is present, in which ca
 XXX: https://tools.ietf.org/html/rfc3711
 XXX: https://tools.ietf.org/html/rfc5763
 
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
-
-XXX
-
 ## ZRTP
 
 XXX: http://zfoneproject.com/faq.html#keycontinuity
 
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
-
-XXX
-
 ## SS-TLS
 
-XXX
-
-https://www.esat.kuleuven.be/cosic/publications/article-2806.pdf
-
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
-
-XXX
+XXX: https://www.esat.kuleuven.be/cosic/publications/article-2806.pdf
 
 ## WireGuard
 
-XXX
-
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
-
-XXX
+XXX: https://www.wireguard.com/papers/wireguard.pdf
 
 ## NoiseSocket
 
-XXX
-
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
-
-XXX
+XXX: http://noiseprotocol.org/specs/noisesocket.html
 
 ## CurveCP
-
-XXX
-
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
 
 XXX
 
@@ -545,31 +471,7 @@ XXX
 
 XXX
 
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
-
-XXX
-
 ## Signal
-
-XXX
-
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
 
 XXX
 
@@ -580,31 +482,9 @@ XXX
 XXX: https://gitweb.torproject.org/torspec.git/tree/proposals/216-ntor-handshake.txt
 XXX: http://www.cypherpunks.ca/~iang/pubs/torsec.pdf
 
-### Protocol descriptions
-
-XXX
-
-### Protocol features
-
-XXX
-
-### Protocol dependencies
-
 ## TAP
 
 XXX: https://svn.torproject.org/svn/projects/design-paper/tor-design.pdf
-
-## CurveCP
-
-XXX
-
-## OTR
-
-XXX
-
-## ZRTP 
-
-XXX
 
 # Common Transport Security Features
 

--- a/draft-pauly-taps-transport-security.md
+++ b/draft-pauly-taps-transport-security.md
@@ -639,12 +639,12 @@ handshake begins or the keys are negotiated.
 - Identity and Private Keys  
 The application can provide its identities (certificates) and private keys, or
 mechanisms to access these, to the security protocol to use during handshakes.  
-Protocols: TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2
+Protocols: TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2, WireGuard, SRTP
 
 - Supported Algorithms (Key Exchange, Signatures and Ciphersuites)  
 The application can choose the algorithms that are supported for key exchange,
 signatures, and ciphersuites.  
-Protocols: TLS, DTLS, QUIC + TLS, MinimalT, tcpcrypt, IKEv2
+Protocols: TLS, DTLS, QUIC + TLS, MinimalT, tcpcrypt, IKEv2, SRTP
 
 - Session Cache  
 The application provides the ability to save and retrieve session state (tickets,
@@ -654,7 +654,7 @@ Protocols: TLS, DTLS, QUIC + TLS, MinimalT
 - Authentication Delegate  
 The application provides access to a separate module that will provide authentication,
 using EAP for example.  
-Protocols: IKEv2
+Protocols: IKEv2, SRTP
 
 ## Handshake Interfaces
 
@@ -663,23 +663,23 @@ the application, record protocol, and transport once the handshake is active.
 
 - Send Handshake Messages  
 The handshake protocol needs to be able to send messages over a transport to the remote peer to establish trust and negotiate keys.  
-Protocols: All (TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2)
+Protocols: All (TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2, WireGuard, SRTP (DTLS))
 
 - Receive Handshake Messages  
 The handshake protocol needs to be able to receive messages from the remote peer
 over a transport to establish trust and negotiate keys.  
-Protocols: All (TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2)
+Protocols: All (TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2, WireGuard, SRTP (DTLS))
 
 - Identity Validation  
 During a handshake, the security protocol will conduct identity validation of the peer.
-This can call into the application to offload validation.  
-Protocols: All (TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2)
+This can call into the application to offload validation.
+Protocols: All (TLS, DTLS, QUIC + TLS, MinimalT, CurveCP, IKEv2, WireGuard, SRTP (DTLS))
 
 - Source Address Validation  
 The handshake protocol may delegate validation of the remote peer that has sent
 data to the transport protocol or application. This involves sending a cookie
 exchange to avoid DoS attacks.  
-Protocols: QUIC + TLS
+Protocols: QUIC + TLS, DTLS, WireGuard
 
 - Key Update  
 The handshake protocol may be instructed to update its keying material, either
@@ -688,7 +688,7 @@ Protocols: TLS, DTLS, QUIC + TLS, MinimalT, tcpcrypt, IKEv2
 
 - Pre-Shared Key Export  
 The handshake protocol will generate one or more keys to be used for record encryption/decryption and authentication. These may be explicitly exportable to the application, traditionally limited to direct  export to the record protocol, or inherently non-exportable because the keys must be used directly in conjunction with the record protocol.  
-    - Explict export: TLS (for QUIC), tcpcrypt, IKEv2
+    - Explict export: TLS (for QUIC), tcpcrypt, IKEv2, DTLS (for SRTP)
     - Direct export: TLS, DTLS, MinimalT
     - Non-exportable: CurveCP
 
@@ -699,19 +699,19 @@ Record interfaces are the points of interaction between a record protocol and th
 - Pre-Shared Key Import  
 Either the handshake protocol or the application directly can supply pre-shared keys for the record protocol use for encryption/decryption and authentication. If the application can supply keys directly, this is considered explicit import; if the handshake protocol traditionally provides the keys directly, it is considered direct import; if the keys can only be shared by the handshake, they are considered non-importable.
     - Explict import: QUIC, ESP
-    - Direct import: TLS, DTLS, MinimalT, tcpcrypt
+    - Direct import: TLS, DTLS, MinimalT, tcpcrypt, WireGuard
     - Non-importable: CurveCP
 
 - Encrypt application data  
 The application can send data to the record protocol to encrypt it into a format that can be sent on the underlying transport. The encryption step may require that the application data is treated as a stream or as datagrams, and that the transport to send the encrypted records present a stream or datagram interface.  
     - Stream-to-Stream Protocols: TLS, tcpcrypt
-    - Datagram-to-Datagram Protocols: DTLS, ESP
+    - Datagram-to-Datagram Protocols: DTLS, ESP, SRTP, WireGuard
     - Stream-to-Datagram Protocols: QUIC ((Editor's Note: This depends on the interface QUIC exposes to applications.))
 
 - Decrypt application data  
 The application can receive data from its transport to be decrypted using record protocol. The decryption step may require that the incoming transport data is presented as a stream or as datagrams, and that the resulting application data is a stream or datagrams.  
     - Stream-to-Stream Protocols: TLS, tcpcrypt
-    - Datagram-to-Datagram Protocols: DTLS, ESP
+    - Datagram-to-Datagram Protocols: DTLS, ESP, SRTP, WireGuard
     - Datagram-to-Stream Protocols: QUIC ((Editor's Note: This depends on the interface QUIC exposes to applications.))
 
 - Key Expiration  
@@ -720,7 +720,7 @@ Protocols: ESP ((Editor's note: One may consider TLS/DTLS to also have this inte
 
 - Transport mobility  
 The record protocol can be signaled that it is being migrated to another transport or interface due to connection mobility, which may reset address and state validation.  
-Protocols: QUIC, MinimalT, CurveCP, ESP
+Protocols: QUIC, MinimalT, CurveCP, ESP, WireGuard (roaming)
 
 # IANA Considerations
 

--- a/draft-pauly-taps-transport-security.md
+++ b/draft-pauly-taps-transport-security.md
@@ -278,9 +278,9 @@ further records, are sent over this stream. This TLS connection follows the TLS 
 and inherits the security properties of TLS. The handshake generates keys, which are
 then exported to the rest of the QUIC connection, and are used to protect the rest of the streams.
 
-Initial QUIC messages are encrypted using "fixed" keys derived from the QUIC version and 
-public packet information (Connection ID).
-Once handshake has generated keys, subsequent messages are encrypted. The TLS 1.3
+Initial QUIC messages (packets) are encrypted using "fixed" keys derived from the QUIC version and 
+public packet information (Connection ID). Packets are later encrypted using keys derived
+from the TLS traffic secret upon handshake completion. The TLS 1.3
 handshake for QUIC is used in either a single-RTT mode or a fast-open zero-RTT mode. When
 zero-RTT handshakes are possible, the encryption first transitions to use the zero-RTT keys
 before using single-RTT handshake keys after the next TLS flight.
@@ -517,7 +517,8 @@ these algorithms, new message types using new algorithms must be introduced.
 WireGuard is designed to be entirely stateless, modulo the CryptoKey routing table, which has size
 linear with the number of trusted peers. If a WireGuard receiver is under heavy load and cannot process
 a packet, e.g., cannot spare CPU cycles for point multiplication, it can reply with a cookie similar
-to DTLS and IKEv2. 
+to DTLS and IKEv2. This cookie only proves IP address ownership. Any rate limiting scheme can be applied
+to packets coming from non-spoofed addresses.
 
 ### Protocol features
 

--- a/draft-pauly-taps-transport-security.md
+++ b/draft-pauly-taps-transport-security.md
@@ -172,6 +172,9 @@ for the server. It is assumed that the client must always store some state infor
 - Application-layer protocol negotiation.
 - Transparent data segmentation.
 
+<!-- caw: possibles to add -->
+- identity hiding
+
 ### Protocol Dependencies
 
 - TCP for in-order, reliable transport.
@@ -468,6 +471,52 @@ XXX
 XXX
 
 ### Protocol dependencies
+
+XXX
+
+## Noise Socket/Link
+
+XXX: https://noiseprotocol.org/docs/noise_stanford_seminar_2016.pdf
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+
+## Signal
+
+XXX
+
+## Pond
+
+XXX
+
+## NTor 
+
+XXX: https://gitweb.torproject.org/torspec.git/tree/proposals/216-ntor-handshake.txt
+XXX: http://www.cypherpunks.ca/~iang/pubs/torsec.pdf
+
+## TAP
+
+XXX: https://svn.torproject.org/svn/projects/design-paper/tor-design.pdf
+
+## CurveCP
+
+XXX
+
+## OTR
+
+XXX
+
+## ZRTP 
 
 XXX
 

--- a/draft-pauly-taps-transport-security.md
+++ b/draft-pauly-taps-transport-security.md
@@ -80,7 +80,7 @@ This document provides a survey of commonly used or notable network security pro
 
 # Introduction
 
-This document provides a survey of commonly used or notable network security protocols, with a focus on how they interact and integrate with applications and transport protocols.  Its goal is to supplement efforts to define and catalog transport services {{RFC8095}} by describing the interfaces required to add security protocols. It examines Transport Layer Security (TLS), Datagram Transport Layer Security (DTLS), Quick UDP Internet Connections with TLS (QUIC + TLS), MinimalT, CurveCP, tcpcrypt, and Internet Key Exchange with Encapsulating Security Protocol (IKEv2 + ESP). This survey is not limited to protocols developed within the scope or context of the IETF.
+This document provides a survey of commonly used or notable network security protocols, with a focus on how they interact and integrate with applications and transport protocols.  Its goal is to supplement efforts to define and catalog transport services {{RFC8095}} by describing the interfaces required to add security protocols. It examines Transport Layer Security (TLS), Datagram Transport Layer Security (DTLS), Quick UDP Internet Connections with TLS (QUIC + TLS), MinimalT, CurveCP, tcpcrypt, Internet Key Exchange with Encapsulating Security Protocol (IKEv2 + ESP), SRTP, and WireGuard. This survey is not limited to protocols developed within the scope or context of the IETF.
 
 For each protocol, this document provides a brief description, the security features it provides, and the dependencies it has on the underlying transport. This is followed by defining the set of transport security features shared by these protocols. Finally, we distill the application and transport interfaces provided by the transport security protocols.
 
@@ -438,6 +438,38 @@ ESP packets are sent directly over IP, except when a NAT is present, in which ca
 #### ESP
 
 - Since ESP is below transport protocols, it does not have any dependencies on the transports themselves, other than on UDP or TCP for NAT traversal.
+
+## SRTP
+
+XXX
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
+
+## WireGuard
+
+XXX
+
+### Protocol descriptions
+
+XXX
+
+### Protocol features
+
+XXX
+
+### Protocol dependencies
+
+XXX
 
 # Common Transport Security Features
 


### PR DESCRIPTION
Future protocols include OTR, Ntor, TAP, ATLS, ZRTP, and NoiseSocket. We can always add them in a rev before London!