### PR TITLE
Add OpenVPN section

### DIFF
--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -13,6 +13,15 @@ pi: [toc, sortrefs, symrefs]
 
 author:
   -
+    ins: C. A. Wood
+    name: Christopher A. Wood
+    role: editor
+    org: Apple Inc.
+    street: One Apple Park Way
+    city: Cupertino, California 95014
+    country: United States of America
+    email: cawood@apple.com
+  -
     ins: T. Enghardt
     name: Theresa Enghardt
     org: TU Berlin
@@ -44,14 +53,6 @@ author:
     city: Cambridge, MA 02144
     country: United States of America
     email: krose@krose.org
-  -
-    ins: C. A. Wood
-    name: Christopher A. Wood
-    org: Apple Inc.
-    street: One Apple Park Way
-    city: Cupertino, California 95014
-    country: United States of America
-    email: cawood@apple.com
 
 normative:
     RFC2385:

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -170,6 +170,12 @@ normative:
     OpenVPN:
       title: OpenVPN cryptographic layer
       url: https://openvpn.net/community-resources/openvpn-cryptographic-layer/
+    BlowFish:
+      title: The Blowfish Encryption Algorithm
+      url: https://www.schneier.com/academic/blowfish/
+      authors:
+        -
+          ins: B. Schneier
 
 --- abstract
 
@@ -857,8 +863,8 @@ and the per-message nonce in the clear. Everything else is encrypted.
 
 ## OpenVPN
 
-OpenVPN {{OpenVPN}} is a commonly used protocol designed to replace IPsec. A
-major goal of this protocol is to provide an easy-to-use VPN. OpenVPN
+OpenVPN {{OpenVPN}} is a commonly used protocol designed as an alternative to
+IPsec. A major goal of this protocol is to provide an easy-to-use VPN. OpenVPN
 encapsulates either IP packets or Ethernet frames within a secure tunnel and
 can run over UDP or TCP.
 
@@ -866,7 +872,7 @@ can run over UDP or TCP.
 
 OpenVPN facilitates authentication using either a pre-shared static key or
 using X.509 certificates and TLS. In pre-shared key mode, OpenVPN derives
-keys for encryption and authentication directly from one or multiple static
+keys for encryption and authentication directly from one or multiple symmetric
 keys. In TLS mode, OpenVPN encapsulates a TLS handshake, in which both peers
 must present a certificate for authentication. After the handshake, both sides
 contribute random source material to derive keys for encryption and
@@ -876,20 +882,20 @@ pre-shared key or passphrase. Furthermore, it supports rekeying using TLS.
 
 After authentication and key exchange, OpenVPN encrypts payload data, i.e., IP
 packets or Ethernet frames, and signs the payload using an HMAC function. The
-default cipher is BlowFish and the default message digest algorithm is SHA1,
-but an application can select an arbitrary cipher, key size, and message digest
-algorithm for the HMAC. OpenVPN peers may also support cipher negotiation
-(NCP). If both hosts allow, they can upgrade the cipher to AES-256-GCM.
-Blocks are padded to an even multiple of block size.
+default cipher is BlowFish {{BlowFish}} and the default message digest
+algorithm is SHA1, but an application can select an arbitrary cipher, key size,
+and message digest algorithm for the HMAC. OpenVPN peers support cipher
+negotiation (NCP) since version 2.4, in which case they will upgrade the cipher
+to AES-256-GCM by default.
 
 OpenVPN can run over TCP or UDP. When running over UDP, OpenVPN provides a
 simple reliability layer for control packets such as the TLS handshake and key
 exchange. It assigns sequence numbers to packets, acknowledges packets it
-receives, and retransmits packets it deems lost. This reliability layer is not
-used for data packets, which prevents the problem of two reliability mechanisms
-being encapsulated within each other. When running over TCP, OpenVPN includes
-the packet length in the header, which allows the peer to deframe the TCP
-stream into messages.
+receives, and retransmits packets it deems lost. Similar to DTLS, this
+reliability layer is not used for data packets, which prevents the problem of
+two reliability mechanisms being encapsulated within each other. When running
+over TCP, OpenVPN includes the packet length in the header, which allows the
+peer to deframe the TCP stream into messages.
 
 For replay protection, OpenVPN assigns an identifier to each outgoing packet,
 which is unique for the packet and the currently used key. In pre-shared key
@@ -901,17 +907,17 @@ each key, as it can trigger rekeying if needed.
 
 OpenVPN supports connection mobility by allowing a peer to change its IP
 address during an ongoing session. When configured accordingly, a host will
-accept packets for a session from any IP address, as long as the packets are
-correctly authenticated.
+accept packets for a session from any IP address, as long as the packets pass
+all authentication checks.
 
 
 ### Protocol Features
 
-- Peer authentication using certificates or pre-shared key
+- Peer authentication using certificates or pre-shared key.
 - Mandatory mutual authentication.
-- Connection mobility
-- Out-of-order record receipt
-- Length-hiding padding
+- Connection mobility.
+- Out-of-order record receipt.
+- Length-hiding padding.
 
 See also the properties of TLS.
 

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -13,6 +13,14 @@ pi: [toc, sortrefs, symrefs]
 
 author:
   -
+    ins: T. Enghardt
+    name: Theresa Enghardt
+    org: TU Berlin
+    street: Marchstr. 23
+    city: 10587 Berlin
+    country: Germany
+    email: theresa@inet.tu-berlin.de
+  -
     ins: T. Pauly
     name: Tommy Pauly
     org: Apple Inc.
@@ -44,14 +52,6 @@ author:
     city: Cupertino, California 95014
     country: United States of America
     email: cawood@apple.com
-  -
-    ins: T. Enghardt
-    name: Theresa Enghardt
-    org: TU Berlin
-    street: Marchstr. 23
-    city: 10587 Berlin
-    country: Germany
-    email: theresa@inet.tu-berlin.de
 
 normative:
     RFC2385:
@@ -434,10 +434,12 @@ See also the features from TLS.
 
 ### Protocol Dependencies
 
+- DTLS relies on UDP.
 - The DTLS record protocol explicitly encodes record lengths, so although it runs over a datagram transport, it does not rely on the transport protocol's framing beyond requiring transport-level reconstruction of datagrams fragmented over packets.
 (Note: DTLS 1.3 short header records omit the explicit length field.)
 - UDP 4-tuple uniqueness, or the connection identifier extension, for demultiplexing.
 - Path MTU discovery.
+- For the handshake: Reliable, in-order transport. DTLS provides its own reliability.
 
 ## (IETF) QUIC with TLS
 
@@ -478,6 +480,7 @@ See also the properties of TLS.
 
 - QUIC transport relies on UDP.
 - QUIC transport relies on TLS 1.3 for key exchange, peer authentication, and shared secret derivation.
+- For the handshake: Reliable, in-order transport. QUIC provides its own reliability.
 
 ### Variant: Google QUIC {#section-gquic}
 
@@ -640,6 +643,7 @@ complete system security.
 
 ### Protocol Dependencies
 
+- Secure RTP can run over UDP or TCP.
 - External key derivation and management protocol, e.g., DTLS {{RFC5763}}.
 - External identity management protocol, e.g., SIP Authenticated Identity Management
   {{RFC4474}}, WebRTC Security Architecture {{I-D.ietf-rtcweb-security-arch}}.
@@ -803,6 +807,7 @@ shared tunnels, and congestion control state is shared across connections betwee
 
 ### Protocol Dependencies
 
+- MinimalT relies on UDP.
 - A DNS-like resolution service to obtain location information (an IP address) and ephemeral keys.
 - A PKI trust store for certificate validation.
 
@@ -864,9 +869,10 @@ and the per-message nonce in the clear. Everything else is encrypted.
 ## OpenVPN
 
 OpenVPN {{OpenVPN}} is a commonly used protocol designed as an alternative to
-IPsec. A major goal of this protocol is to provide an easy-to-use VPN. OpenVPN
-encapsulates either IP packets or Ethernet frames within a secure tunnel and
-can run over UDP or TCP.
+IPsec. A major goal of this protocol is to provide a VPN that is simple to
+configure and works over a variety of transports. OpenVPN encapsulates either
+IP packets or Ethernet frames within a secure tunnel and can run over UDP or
+TCP.
 
 ### Protocol Description
 
@@ -907,8 +913,7 @@ each key, as it can trigger rekeying if needed.
 
 OpenVPN supports connection mobility by allowing a peer to change its IP
 address during an ongoing session. When configured accordingly, a host will
-accept packets for a session from any IP address, as long as the packets pass
-all authentication checks.
+accept authenticated packets for a session from any IP address.
 
 
 ### Protocol Features
@@ -923,7 +928,7 @@ See also the properties of TLS.
 
 ### Protocol Dependencies
 
-- For control packets such as handshake and key exchange: Reliable transport. Reliability is provided either by TCP, or by OpenVPN's own reliability layer when using UDP.
+- For control packets such as handshake and key exchange: Reliable, in-order transport. Reliability is provided either by TCP, or by OpenVPN's own reliability layer when using UDP.
 
 # Security Features and Application Dependencies
 


### PR DESCRIPTION
As promised, here's the first draft of the OpenVPN section.
I think I captured all relevant properties and dependencies, and actually I think OpenVPN is quite an interesting combination.

My sources are:
* https://openvpn.net/community-resources/openvpn-cryptographic-layer/ - provides a good overview
* https://openvpn.net/community-resources/openvpn-protocol/ - provides some detailed protocol mechanics
* https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/ - current version, mentions current default ciphers, mobility, cipher negotiation

Unfortunately, I could not find a stable reference. The current release is version 2.4.6. Most books, PDFs, etc., both refer to older versions and do not contain the relevant information. The only sort-of stable page would be version 1 of this wiki page, which was migrated from an old web server 4 years ago: https://community.openvpn.net/openvpn/wiki/SecurityOverview?version=1 

I'm still wondering if it makes sense to mention the version this section is based on, if it makes sense to cite more of these web pages, and if it makes sense to call out the lack of stable reference.
What do you think?