### PR TITLE
Add architectural discussion on handshake vs. record protocols

### DIFF
--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -278,7 +278,8 @@ these are not intended for generic application use.
 Secure RTP (SRTP) is a profile for RTP that provides confidentiality,
 message authentication, and replay protection for RTP data packets
 and RTP control protocol (RTCP) packets {{?RFC3711}}.
-SRTP can use different handshake protocols, such as DTLS in DTLS-SRTP {{?RFC5764}}.
+SRTP can use different handshake protocols, such as DTLS in DTLS-SRTP {{?RFC5764}}
+or ZRTP {{?RFC6189}}.
 
 ### ZRTP for Media Path Key Agreement
 


### PR DESCRIPTION
This PR mainly changes the beginning of Section 3, Transport Security Protocol Descriptions.

It substitutes the sentence on how the document is structured (which I moved to the Introduction) with a brief discussion on the classification we use in Section 3. This includes an explanation of the difference between handshake and record protocols as suggested by Ekr.

Furthermore, this PR references DTLS-SRTP, renames "QUIC + TLS" to "IETF QUIC", and mentions that OpenVPN can use TLS as a handshake protocol.