### PR TITLE
Summary table for Section 5, fixes #70

### DIFF
--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -529,6 +529,7 @@ data to the transport protocol or application. This involves sending a cookie
 exchange to avoid DoS attacks.
   - DTLS
   - QUIC
+  - IKEv2
   - WireGuard
 
 ## Post-Connection Interfaces
@@ -591,7 +592,7 @@ The following table summarizes which protocol exposes which interface.
 | tcpcrypt  |     | x   |     |    |    | D    |    |     | x  | x  | E    |    |    |
 | MinimalT  | x   | x   |     | x  |    | D    | x  |     | x  | x  | D    |    | x  |
 | CurveCP   | x   |     |     |    |    | N    | x  |     |    |    | N    |    | x  |
-| IKEv2+ESP | x   | x   |     |    | x  | E    | x  |     | x  | x  | E    | x  | x  |
+| IKEv2+ESP | x   | x   |     |    | x  | E    | x  | x   | x  | x  | E    | x  | x  |
 | WireGuard | x   |     |     |    |    | D    | x  | x   |    |    |      |    | x  |
 | OpenVPN   |     |     |     |    |    |      | x  |     |    |    |      |    |    |
 |---

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -506,7 +506,7 @@ keys directly, this is considered explicit import; if the handshake protocol tra
 provides the keys directly, it is considered direct import; if the keys can only be shared by
 the handshake, they are considered non-importable.
   - Explicit import: QUIC, ESP, OpenVPN
-  - Direct import: TLS, DTLS, tcpcrypt, MinimalT, WireGuard
+  - Direct import: TLS, DTLS, tcpcrypt, MinimalT, WireGuard, IKEv2
   - Non-importable: CurveCP
 
 ## Connection Interfaces
@@ -562,7 +562,7 @@ These may be explicitly exportable to the application, traditionally limited to 
 or inherently non-exportable because the keys must be used directly in conjunction with the record protocol.
   - Explicit export: TLS (for QUIC), DTLS (for SRTP), tcpcrypt, IKEv2, OpenVPN
   - Direct export: TLS, DTLS, MinimalT
-  - Non-exportable: CurveCP
+  - Non-exportable: CurveCP, ESP, WireGuard
 
 - Key Expiration (KE):
 The record protocol can signal that its keys are expiring due to reaching a time-based deadline, or a use-based
@@ -594,9 +594,9 @@ The following table summarizes which protocol exposes which interface.
 | tcpcrypt  |     | x   |     | x  | x  | D    |    |     | x  | x  | E    |    |    |
 | MinimalT  | x   | x   |     | x  |    | D    | x  |     | x  | x  | D    |    | x  |
 | CurveCP   | x   |     |     |    |    | N    | x  |     |    |    | N    |    | x  |
-| IKEv2     | x   | x   |     |    | x  |      | x  | x   | x  | x  | E    |    | x  |
-| ESP       |     |     |     |    |    | E    |    |     |    |    |      | x  |    |
-| WireGuard | x   |     |     |    |    | D    | x  | x   |    |    |      |    | x  |
+| IKEv2     | x   | x   |     |    | x  | D    | x  | x   | x  | x  | E    |    | x  |
+| ESP       |     |     |     |    |    | E    |    |     |    |    | N    | x  |    |
+| WireGuard | x   |     |     |    |    | D    | x  | x   |    |    | N    |    | x  |
 | OpenVPN   | x   | x   |     |    |    | E    | x  |     | x  |    | E    |    |    |
 |---
 

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -591,7 +591,7 @@ The following table summarizes which protocol exposes which interface.
 | DTLS      | x   | x   | x   | x  |    | D    | x  | x   | x  | x  | D    |    |    |
 | SRTP      | x   | x   |     |    | x  |      | x  |     |    |    | E    |    |    |
 | QUIC      | x   | x   | x   | x  |    | E    | x  | x   | x  | x  | E    |    | x  |
-| tcpcrypt  |     | x   |     |    |    | D    |    |     | x  | x  | E    |    |    |
+| tcpcrypt  |     | x   |     | x  | x  | D    |    |     | x  | x  | E    |    |    |
 | MinimalT  | x   | x   |     | x  |    | D    | x  |     | x  | x  | D    |    | x  |
 | CurveCP   | x   |     |     |    |    | N    | x  |     |    |    | N    |    | x  |
 | IKEv2     | x   | x   |     |    | x  |      | x  | x   | x  | x  | E    |    | x  |

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -597,7 +597,7 @@ The following table summarizes which protocol exposes which interface.
 | IKEv2     | x   | x   |     |    | x  |      | x  | x   | x  | x  | E    |    | x  |
 | ESP       |     |     |     |    |    | E    |    |     |    |    |      | x  |    |
 | WireGuard | x   |     |     |    |    | D    | x  | x   |    |    |      |    | x  |
-| OpenVPN   |     |     |     |    |    |      | x  |     |    |    |      |    |    |
+| OpenVPN   | x   | x   |     |    |    | E    | x  |     | x  |    | E    |    |    |
 |---
 
 x=Interface is exposed  

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -449,6 +449,7 @@ conventions in {{?I-D.ietf-taps-interface}} and {{?I-D.ietf-taps-arch}}.
 
 Note that not all protocols support each interface.
 The table in {{interface-protocols-table}} summarizes which protocol exposes which of the interfaces.
+In the following sections, we provide abbreviations of the interface names to use in the summary table.
 
 ## Pre-Connection Interfaces
 

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -589,7 +589,7 @@ The following table summarizes which protocol exposes which interface.
 |:----------|:---:|:---:|:---:|:--:|:--:|:----:|:--:|:---:|:--:|:--:|:----:|:--:|:--:|
 | TLS       | x   | x   | x   | x  |    | x    | x  |     | x  | x  | x    |    |    |
 | DTLS      | x   | x   | x   | x  |    | x    | x  | x   | x  | x  | x    |    |    |
-| SRTP      | x   | x   |     |    | x  |      | x  |     |    |    |      |    |    |
+| ZRTP      | x   | x   |     | x  |    | x    | x  |     | x  |    |      |    |    |
 | QUIC      | x   | x   | x   | x  |    | x    | x  | x   | x  | x  |      |    | x  |
 | tcpcrypt  |     | x   |     | x  | x  | x    |    |     | x  | x  | x    |    |    |
 | MinimalT  | x   | x   |     | x  |    | x    | x  |     | x  | x  | x    |    | x  |

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -587,24 +587,21 @@ The following table summarizes which protocol exposes which interface.
 |---
 | Protocol  | IPK | ALG | EXT | CM | AD | PSKI | IV | SAV | CT | KU | PSKE | KE | ME |
 |:----------|:---:|:---:|:---:|:--:|:--:|:----:|:--:|:---:|:--:|:--:|:----:|:--:|:--:|
-| TLS       | x   | x   | x   | x  |    | D    | x  |     | x  | x  | D    |    |    |
-| DTLS      | x   | x   | x   | x  |    | D    | x  | x   | x  | x  | D    |    |    |
-| SRTP      | x   | x   |     |    | x  |      | x  |     |    |    | E    |    |    |
-| QUIC      | x   | x   | x   | x  |    | E    | x  | x   | x  | x  | E    |    | x  |
-| tcpcrypt  |     | x   |     | x  | x  | D    |    |     | x  | x  | E    |    |    |
-| MinimalT  | x   | x   |     | x  |    | D    | x  |     | x  | x  | D    |    | x  |
-| CurveCP   | x   |     |     |    |    | N    | x  |     |    |    | N    |    | x  |
-| IKEv2     | x   | x   |     |    | x  | D    | x  | x   | x  | x  | E    |    | x  |
-| ESP       |     |     |     |    |    | E    |    |     |    |    | N    | x  |    |
-| WireGuard | x   |     |     |    |    | D    | x  | x   |    |    | N    |    | x  |
-| OpenVPN   | x   | x   |     |    |    | E    | x  |     | x  |    | E    |    |    |
+| TLS       | x   | x   | x   | x  |    | x    | x  |     | x  | x  | x    |    |    |
+| DTLS      | x   | x   | x   | x  |    | x    | x  | x   | x  | x  | x    |    |    |
+| SRTP      | x   | x   |     |    | x  |      | x  |     |    |    |      |    |    |
+| QUIC      | x   | x   | x   | x  |    | x    | x  | x   | x  | x  |      |    | x  |
+| tcpcrypt  |     | x   |     | x  | x  | x    |    |     | x  | x  | x    |    |    |
+| MinimalT  | x   | x   |     | x  |    | x    | x  |     | x  | x  | x    |    | x  |
+| CurveCP   | x   |     |     |    |    |      | x  |     |    |    |      |    | x  |
+| IKEv2     | x   | x   |     |    | x  | x    | x  | x   | x  | x  | x    |    | x  |
+| ESP       |     |     |     |    |    | x    |    |     |    |    |      | x  |    |
+| WireGuard | x   |     |     |    |    | x    | x  | x   |    |    |      |    | x  |
+| OpenVPN   | x   | x   |     |    |    | x    | x  |     | x  |    | x    |    |    |
 |---
 
 x=Interface is exposed  
 (blank)=Interface is not exposed  
-E=Interface is exposed (Explicit import/export)  
-D=Interface is exposed (Direct import/export)  
-N=Interface is not exposed (Non-importable/exportable)
 
 # IANA Considerations
 

--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -593,7 +593,8 @@ The following table summarizes which protocol exposes which interface.
 | tcpcrypt  |     | x   |     |    |    | D    |    |     | x  | x  | E    |    |    |
 | MinimalT  | x   | x   |     | x  |    | D    | x  |     | x  | x  | D    |    | x  |
 | CurveCP   | x   |     |     |    |    | N    | x  |     |    |    | N    |    | x  |
-| IKEv2+ESP | x   | x   |     |    | x  | E    | x  | x   | x  | x  | E    | x  | x  |
+| IKEv2     | x   | x   |     |    | x  |      | x  | x   | x  | x  | E    |    | x  |
+| ESP       |     |     |     |    |    | E    |    |     |    |    |      | x  |    |
 | WireGuard | x   |     |     |    |    | D    | x  | x   |    |    |      |    | x  |
 | OpenVPN   |     |     |     |    |    |      | x  |     |    |    |      |    |    |
 |---


### PR DESCRIPTION
Summarized the interfaces exposed to applications in a table to make Section 5 easier to read, see #70.

I pretty much used the information as given in Section 5.1 to 5.3 as is, however, I have the following issues/questions:

- Are we intentionally missing gQUIC? Is it the same as (IETF) QUIC?
- Are we intentionally missing ZRTP?
- Some entries list IKEv2, some list ESP - I merged the two, as this document considers them together according to Section 3.4.1. Is this correct here?
- It looks to me like OpenVPN is missing some interfaces. For example, as far as I know, it is possible to provide an identity and private key for OpenVPN, and it is possible to choose which algorithms to support. Should we add these?
- For Pre-Shared Key Import/Export: Is "non-importable" the same as "Interface is not exposed"?
- For Pre-Shared Key Export: Is "TLS (for QUIC)" just "QUIC" and is "DTLS (for SRTP)" just "SRTP"? TLS and DTLS are also given on their own below.
- Do we want to delete the lists of protocols from Sections 5.1 to 5.3 once we have completed the table in Section 5.4?