### PR TITLE
Update mobility for IKEv2

### DIFF
--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -571,7 +571,7 @@ as use of a new Connection Identifier (CID).
   - QUIC
   - MinimalT
   - CurveCP
-  - ESP
+  - IKEv2 {{?RFC4555}}
   - WireGuard
 
 # IANA Considerations


### PR DESCRIPTION
Address #76. IKE has mobility via MOBIKE (which makes ESP move, but it's more a property of IKE)