### PR TITLE
Add tcpcrypt capabilities

### DIFF
--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -483,6 +483,7 @@ keying material, and server parameters) that may be used to resume the security 
   - TLS
   - DTLS
   - QUIC
+  - tcpcrypt
   - MinimalT
 
 - Authentication Delegation:
@@ -490,6 +491,7 @@ The application provides access to a separate module that will provide authentic
 using EAP for example.
   - SRTP
   - IKEv2
+  - tcpcrypt
 
 - Pre-Shared Key Import:
 Either the handshake protocol or the application directly can supply pre-shared keys for the


### PR DESCRIPTION
Part of #71 

This addresses two of Ekr's comments about tcpcrypt in https://mailarchive.ietf.org/arch/msg/taps/jrFbHFIXMpN9hi8siJKfvo-YQfU. The remaining (tcpcrypt occurring before TCP reassembly) I believe is invalid.