### PR TITLE
Connection termination: mention layering, fix #75

### DIFF
--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -533,7 +533,9 @@ exchange to avoid DoS attacks.
 
 - Connection Termination:
 The security protocol may be instructed to tear down its connection and session information.
-This is needed by some protocols to prevent application data truncation attacks.
+This is needed by some protocols, e.g., to prevent application data truncation attacks in 
+which an attacker terminates an underlying insecure connection-oriented protocol to terminate 
+the session.
   - TLS
   - DTLS
   - QUIC


### PR DESCRIPTION
Add half a sentence to Connection Termination to address #75, which complained that this part ignores layering.

I guess IKEv2 is the only protocol there that is not at the same layer as TCP or above. So maybe for IKEv2, the Connection Termination interface prevents a different attack (at least I didn't find anything on data truncation for IKEv2), but I think that's okay. Data truncation is just an example and we don't need to enumerate all possible attacks.