### PR TITLE
Change order of protocols in "PSK Import" as suggested by Opsdir review

### DIFF
--- a/draft-ietf-taps-transport-security.md
+++ b/draft-ietf-taps-transport-security.md
@@ -518,12 +518,12 @@ in encrypting (and authenticating) communication with a peer.
   - DTLS
   - ZRTP
   - QUIC
-  - ESP
-  - IPsec
-  - OpenVPN
   - tcpcrypt
   - MinimaLT
+  - IPsec
+  - ESP
   - WireGuard
+  - OpenVPN
 
 ## Connection Interfaces
 


### PR DESCRIPTION
Read through the Opsdir review we recently got.

Not sure we want to add anything to that BGP questions, but there was also a minor editorial nit, which this PR fixes.

Now the order of these protocols is the same as in the table.